### PR TITLE
Fix the build script to avoid creating recursive symlinks

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -35,8 +35,9 @@ CMAKE_FLAGS+="-DENABLE_P4TEST=ON "
 CMAKE_FLAGS+="-DENABLE_P4C_GRAPHS=ON "
 
 # Link CAIRN compiler backend into p4c extensions directory
+rm -rf ${P4C_DIR}/extensions
 mkdir -p ${P4C_DIR}/extensions
-ln -s -f ${CAIRN_DIR}/compiler ${P4C_DIR}/extensions/cairn
+ln -s -T ${CAIRN_DIR}/compiler ${P4C_DIR}/extensions/cairn
 
 # Build and install
 mkdir -p ${P4C_DIR}/build


### PR DESCRIPTION
The build script is expected to symlink `cairn/compiler` to `cairn/p4c/extensions/cairn`. But currently, when using the build script multiple times, it will create a recursive symlink `cairn/p4c/extensions/cairn/compiler`. This PR fixes this issue.