### PR TITLE
Update the compiler design description

### DIFF
--- a/compiler/testdata/pass1.p4
+++ b/compiler/testdata/pass1.p4
@@ -1,0 +1,57 @@
+/*
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#include <core.p4>
+
+header eth_h {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+    varbit<32> var_place;
+}
+
+struct header_t {
+    eth_h eth;
+}
+
+struct metadata_t {}
+
+parser TestParser(
+    packet_in pkt,
+    out header_t hdr,
+    inout metadata_t meta
+) {
+    bit<8> x;
+    state start {
+        pkt.extract(hdr.eth, (bit<32>)x); // x is an 32-bit global. This uses the original value of x
+        x = pkt.lookahead<bit<8>>();
+        pkt.extract(hdr.eth, (bit<32>)x); // This uses the new value of x
+        x = pkt.lookahead<bit<8>>();
+        pkt.extract(hdr.eth, (bit<32>)x); // This uses the new value of x
+        transition accept;
+    }
+}
+
+// Construct the package.
+parser Parser<H, M>(
+  packet_in pkt,
+  out H hdr,
+  inout M meta
+);
+package Package<H, M>(
+  Parser<H, M> p
+);
+Package(TestParser()) main;

--- a/compiler/testdata/pass2.p4
+++ b/compiler/testdata/pass2.p4
@@ -1,0 +1,71 @@
+/*
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#include <core.p4>
+
+header eth_h {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+}
+
+header ipv4_h {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    varbit<256>    var;
+}
+
+struct header_t {
+    eth_h eth;
+    ipv4_h ipv4;
+}
+
+struct metadata_t {}
+
+parser TestParser(
+    packet_in pkt,
+    out header_t hdr,
+    inout metadata_t meta
+) {
+    bit<32> x;
+    state start {
+        pkt.extract(hdr.eth); // 112 bits long
+        x = pkt.lookahead<bit<32>>();  // 32 bits long
+        pkt.extract(hdr.ipv4, x);  // 160+x bits long
+        transition accept;
+    }
+}
+
+// Construct the package.
+parser Parser<H, M>(
+  packet_in pkt,
+  out H hdr,
+  inout M meta
+);
+package Package<H, M>(
+  Parser<H, M> p
+);
+Package(TestParser()) main;

--- a/docs/compiler_design.md
+++ b/docs/compiler_design.md
@@ -326,16 +326,22 @@ them see the same value for global variables. A naive solution is to inline the
 new definition of `x` in the above code, so only the original value remains.
 However, inlining potentially changes the order of statements; since some
 statements (specifically, `extract`s) have side effects, inlining is unsound
-until they are eliminated. Instead, we augment each global variable assignment
-with an equivalent local variable declaration, and replace later uses of that
+until they are eliminated. Instead, we replace each global variable assignment
+by an equivalent local variable declaration, and also replace later uses of that
 global with the equivalent local. This way, we can syntactically distinguish
 between the global’s original value and its updated value (the local). The local
-will then be inlined by a later pass, when it is safe to do so. When applied to
-the above example, the transformation would produce the following: `state foo {
-packet.extract(hdr1, x); // x is an 8-bit global. This uses the original value
-of x x = packet.lookahead(bit<8>); x_new = packet.lookahead(bit<8>); // This
-will get inlined later, so no overhead packet.extract(hdr2, x_new); // This uses
-the new value of x transition accept; }`
+will then be inlined by a later pass, when it is safe to do so. Finally, we will update the global variable to the value stored in newly added local variable to guarantee the correctness of its final value.
+When applied to
+the above example, the transformation would produce the following: 
+```
+state foo {
+  packet.extract(hdr1, x); // x is an 8-bit global. This uses the original value of x 
+  x_new = packet.lookahead(bit<8>); // This will get inlined later, so no overhead 
+  packet.extract(hdr2, x_new); // This uses the new value of x 
+  x = x_new; // This will update back the global variable
+  transition accept; 
+}
+```
 
 #### Pass 2: Extract and Lookahead Conversion
 

--- a/docs/compiler_design.md
+++ b/docs/compiler_design.md
@@ -314,9 +314,9 @@ for all later statements, but not earlier ones. See below for an example:
 
 ```
 state foo {
-  packet.extract(hdr1, x); // x is an 8-bit global. This uses the original value of x
-  x = packet.lookahead(bit<8>);
-  packet.extract(hdr2, x); // This uses the new value of x
+  packet.extract(hdr1, (bit<32>)x); // x is an 8-bit global. This uses the original value of x. We need to cast it to bit<32> and put it as one parameter for extract(...).
+  x = packet.lookahead<bit<8>>();
+  packet.extract(hdr2, (bit<32>)x); // This uses the new value of x
   transition accept;
 }
 ```
@@ -335,9 +335,9 @@ When applied to
 the above example, the transformation would produce the following: 
 ```
 state foo {
-  packet.extract(hdr1, x); // x is an 8-bit global. This uses the original value of x 
-  x_new = packet.lookahead(bit<8>); // This will get inlined later, so no overhead 
-  packet.extract(hdr2, x_new); // This uses the new value of x 
+  packet.extract(hdr1, (bit<32>)x); // x is an 8-bit global. This uses the original value of x. We need to cast it to bit<32> and put it as one parameter for extract(...).
+  x_new = packet.lookahead<bit<8>>(); // This will get inlined later, so no overhead 
+  packet.extract(hdr2, (bit<32>)x_new); // This uses the new value of x 
   x = x_new; // This will update back the global variable
   transition accept; 
 }


### PR DESCRIPTION
Fix the formatting problems of compiler_design.md. Some of the previous descriptions are not clear enough, so we add explanations into this file. In addition, I add 2 extra test files for pass1 and pass2.